### PR TITLE
Require at least a space after heading start

### DIFF
--- a/CDMarkdownKit.xcodeproj/project.pbxproj
+++ b/CDMarkdownKit.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		1F66CB682A8EB04C00FC7BA7 /* CDMarkdownKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B2B365B71F3245800078B962 /* CDMarkdownKit.framework */; };
 		1F66CB7A2A8FBC1000FC7BA7 /* TestBold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F66CB792A8FBC1000FC7BA7 /* TestBold.swift */; };
 		1F66CB7C2A8FBC8F00FC7BA7 /* TestCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F66CB7B2A8FBC8F00FC7BA7 /* TestCode.swift */; };
+		1F9A797D2A98B4AF00E153E3 /* TestHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9A797C2A98B4AF00E153E3 /* TestHeader.swift */; };
 		5F0AD09521063D36007B718F /* CDImage+CDMarkdownKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0AD09421063D36007B718F /* CDImage+CDMarkdownKit.swift */; };
 		5F0AD09621063D36007B718F /* CDImage+CDMarkdownKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0AD09421063D36007B718F /* CDImage+CDMarkdownKit.swift */; };
 		5F0AD09721063D36007B718F /* CDImage+CDMarkdownKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0AD09421063D36007B718F /* CDImage+CDMarkdownKit.swift */; };
@@ -180,6 +181,7 @@
 		1F66CB662A8EB04C00FC7BA7 /* TestItalic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestItalic.swift; sourceTree = "<group>"; };
 		1F66CB792A8FBC1000FC7BA7 /* TestBold.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestBold.swift; sourceTree = "<group>"; };
 		1F66CB7B2A8FBC8F00FC7BA7 /* TestCode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCode.swift; sourceTree = "<group>"; };
+		1F9A797C2A98B4AF00E153E3 /* TestHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHeader.swift; sourceTree = "<group>"; };
 		5F0AD09421063D36007B718F /* CDImage+CDMarkdownKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CDImage+CDMarkdownKit.swift"; sourceTree = "<group>"; };
 		B205C6651FC129EB00E74CBA /* CDColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDColor.swift; sourceTree = "<group>"; };
 		B205C66A1FC129FC00E74CBA /* CDFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDFont.swift; sourceTree = "<group>"; };
@@ -281,6 +283,7 @@
 				1F66CB792A8FBC1000FC7BA7 /* TestBold.swift */,
 				1F66CB662A8EB04C00FC7BA7 /* TestItalic.swift */,
 				1F66CB7B2A8FBC8F00FC7BA7 /* TestCode.swift */,
+				1F9A797C2A98B4AF00E153E3 /* TestHeader.swift */,
 				1F02B8592A90D60D0023148B /* TestSyntax.swift */,
 			);
 			path = CDMarkdownKitTests;
@@ -704,6 +707,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F9A797D2A98B4AF00E153E3 /* TestHeader.swift in Sources */,
 				1F66CB7A2A8FBC1000FC7BA7 /* TestBold.swift in Sources */,
 				1F02B85C2A90D6210023148B /* TestHelpers.swift in Sources */,
 				1F66CB7C2A8FBC8F00FC7BA7 /* TestCode.swift in Sources */,

--- a/CDMarkdownKitTests/TestHeader.swift
+++ b/CDMarkdownKitTests/TestHeader.swift
@@ -1,0 +1,52 @@
+//
+// Copyright (c) 2023 Marcel Müller <marcel-mueller@gmx.de>
+//
+// Author Marcel Müller <marcel-mueller@gmx.de>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import XCTest
+import CDMarkdownKit
+
+final class TestHeader: XCTestCase {
+
+    func getParser() -> CDMarkdownParser {
+        let parser = CDMarkdownParser()
+
+        parser.header.backgroundColor = .red
+
+        return parser
+    }
+
+    func testHeaderSingle() throws {
+        let parser = getParser()
+
+        let parsed = parser.parse("# Test")
+        XCTAssertEqual(parsed.string, "Test")
+        XCTAssertTrue(TestHelpers.hasBackgroundColor(testString: parsed, at: 0, color: .red))
+    }
+
+    func testHeaderSingleWithoutSpace() throws {
+        let parser = getParser()
+
+        let parsed = parser.parse("#Test")
+        XCTAssertEqual(parsed.string, "#Test")
+        XCTAssertFalse(TestHelpers.hasBackgroundColor(testString: parsed, at: 0, color: .red))
+    }
+
+
+}

--- a/CDMarkdownKitTests/TestHelpers.swift
+++ b/CDMarkdownKitTests/TestHelpers.swift
@@ -68,5 +68,12 @@ class TestHelpers {
     static func anyMonospaced(testString: NSAttributedString) -> Bool {
         return anyHelper(testString: testString, trait: .traitMonoSpace)
     }
+
+    static func hasBackgroundColor(testString: NSAttributedString, at location: Int, color: UIColor) -> Bool {
+        let attributes = testString.attributes(at: location, effectiveRange: nil)
+
+        return attributes.contains { $0.key == .backgroundColor && ($0.value as! UIColor).isEqualTo(otherColor: color) }
+    }
+
     
 }

--- a/Source/CDMarkdownHeader.swift
+++ b/Source/CDMarkdownHeader.swift
@@ -33,7 +33,7 @@
 
 open class CDMarkdownHeader: CDMarkdownLevelElement {
 
-    fileprivate static let regex = ["^\\s*(#{1,%@})\\s*(.+)$\n*"]
+    fileprivate static let regex = ["^\\s*(#{1,%@})\\s+(.+)$\n*"]
     fileprivate struct CDMarkdownHeadingHashes {
         static let one   = 9
         static let two   = 5


### PR DESCRIPTION
Currently 

```
#test
```

Renders as a heading, but it should only do that when there's at least a space like `# test`