### PR TITLE
Escape code/syntax blocks with base64

### DIFF
--- a/CDMarkdownKit.xcodeproj/project.pbxproj
+++ b/CDMarkdownKit.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		1F66CB682A8EB04C00FC7BA7 /* CDMarkdownKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B2B365B71F3245800078B962 /* CDMarkdownKit.framework */; };
 		1F66CB7A2A8FBC1000FC7BA7 /* TestBold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F66CB792A8FBC1000FC7BA7 /* TestBold.swift */; };
 		1F66CB7C2A8FBC8F00FC7BA7 /* TestCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F66CB7B2A8FBC8F00FC7BA7 /* TestCode.swift */; };
+		1F8538492ADFE12E0011FE81 /* TestEscape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8538482ADFE12E0011FE81 /* TestEscape.swift */; };
 		1F9A797D2A98B4AF00E153E3 /* TestHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9A797C2A98B4AF00E153E3 /* TestHeader.swift */; };
 		5F0AD09521063D36007B718F /* CDImage+CDMarkdownKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0AD09421063D36007B718F /* CDImage+CDMarkdownKit.swift */; };
 		5F0AD09621063D36007B718F /* CDImage+CDMarkdownKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0AD09421063D36007B718F /* CDImage+CDMarkdownKit.swift */; };
@@ -181,6 +182,7 @@
 		1F66CB662A8EB04C00FC7BA7 /* TestItalic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestItalic.swift; sourceTree = "<group>"; };
 		1F66CB792A8FBC1000FC7BA7 /* TestBold.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestBold.swift; sourceTree = "<group>"; };
 		1F66CB7B2A8FBC8F00FC7BA7 /* TestCode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCode.swift; sourceTree = "<group>"; };
+		1F8538482ADFE12E0011FE81 /* TestEscape.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestEscape.swift; sourceTree = "<group>"; };
 		1F9A797C2A98B4AF00E153E3 /* TestHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHeader.swift; sourceTree = "<group>"; };
 		5F0AD09421063D36007B718F /* CDImage+CDMarkdownKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CDImage+CDMarkdownKit.swift"; sourceTree = "<group>"; };
 		B205C6651FC129EB00E74CBA /* CDColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDColor.swift; sourceTree = "<group>"; };
@@ -283,6 +285,7 @@
 				1F66CB792A8FBC1000FC7BA7 /* TestBold.swift */,
 				1F66CB662A8EB04C00FC7BA7 /* TestItalic.swift */,
 				1F66CB7B2A8FBC8F00FC7BA7 /* TestCode.swift */,
+				1F8538482ADFE12E0011FE81 /* TestEscape.swift */,
 				1F9A797C2A98B4AF00E153E3 /* TestHeader.swift */,
 				1F02B8592A90D60D0023148B /* TestSyntax.swift */,
 			);
@@ -707,6 +710,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F8538492ADFE12E0011FE81 /* TestEscape.swift in Sources */,
 				1F9A797D2A98B4AF00E153E3 /* TestHeader.swift in Sources */,
 				1F66CB7A2A8FBC1000FC7BA7 /* TestBold.swift in Sources */,
 				1F02B85C2A90D6210023148B /* TestHelpers.swift in Sources */,

--- a/CDMarkdownKitTests/TestEscape.swift
+++ b/CDMarkdownKitTests/TestEscape.swift
@@ -1,0 +1,39 @@
+//
+// Copyright (c) 2023 Marcel Müller <marcel-mueller@gmx.de>
+//
+// Author Marcel Müller <marcel-mueller@gmx.de>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import XCTest
+import CDMarkdownKit
+
+final class TestEscape: XCTestCase {
+
+    func getParser() -> CDMarkdownParser {
+        let parser = CDMarkdownParser()
+
+        return parser
+    }
+
+    func testEscapeSingle() throws {
+        let parser = getParser()
+
+        let parsed = parser.parse("\\# Hello")
+        XCTAssertEqual(parsed.string, "# Hello")
+    }
+}

--- a/Source/CDMarkdownCode.swift
+++ b/Source/CDMarkdownCode.swift
@@ -64,7 +64,7 @@ open class CDMarkdownCode: CDMarkdownCommonElement {
     open func addAttributes(_ attributedString: NSMutableAttributedString,
                             range: NSRange) {
         let matchString: String = attributedString.attributedSubstring(from: range).string
-        guard let unescapedString = matchString.unescapeUTF16() else { return }
+        guard let unescapedString = matchString.fromBase64() else { return }
         attributedString.replaceCharacters(in: range,
                                            with: unescapedString)
         let range = NSRange(location: range.location,

--- a/Source/CDMarkdownCodeEscaping.swift
+++ b/Source/CDMarkdownCodeEscaping.swift
@@ -62,13 +62,7 @@ open class CDMarkdownCodeEscaping: CDMarkdownElement {
             }
         }
 
-        let escapedString = [UInt16](matchString.utf16)
-            .map { (value: UInt16) -> String in String(format: "%04x",
-                                                       value) }
-            .reduce("") { (string: String, character: String) -> String in
-                return "\(string)\(character)"
-        }
         attributedString.replaceCharacters(in: range,
-                                           with: escapedString)
+                                           with: matchString.toBase64())
     }
 }

--- a/Source/CDMarkdownSyntax.swift
+++ b/Source/CDMarkdownSyntax.swift
@@ -64,7 +64,7 @@ open class CDMarkdownSyntax: CDMarkdownCommonElement {
     open func addAttributes(_ attributedString: NSMutableAttributedString,
                             range: NSRange) {
         let matchString: String = attributedString.attributedSubstring(from: range).string
-        guard var unescapedString = matchString.unescapeUTF16() else { return }
+        guard var unescapedString = matchString.fromBase64() else { return }
 
         // Make sure we show a empty code block, if the block contains nothing
         if unescapedString == "\n" || unescapedString.isEmpty {

--- a/Source/String+CDMarkdownKit.swift
+++ b/Source/String+CDMarkdownKit.swift
@@ -69,6 +69,22 @@ internal extension String {
                       count: utf16Array.count)
     }
 
+    func toBase64() -> String {
+        if let encoded = self.data(using: .utf16)?.base64EncodedString() {
+            return encoded
+        }
+
+        return ""
+    }
+
+    func fromBase64() -> String? {
+        guard let data = Data(base64Encoded: self) else {
+            return nil
+        }
+
+        return String(data: data, encoding: .utf16)
+    }
+
     func range(from nsRange: NSRange) -> Range<String.Index>? {
         guard
             let from16 = utf16.index(utf16.startIndex, offsetBy: nsRange.location, limitedBy: utf16.endIndex),
@@ -84,10 +100,6 @@ internal extension String {
     }
 
     func sizeWithAttributes(_ attributes: [CDAttributedStringKey: Any]? = nil) -> CGSize {
-#if os(macOS)
         return self.size(withAttributes: attributes)
-#else
-        return self.size(withAttributes: attributes)
-#endif
     }
 }


### PR DESCRIPTION
For code and syntax blocks use base64 encoding, instead of the custom one (as it is very slow for large blocks). For simple escape we keep the custom one for now.