### PR TITLE
Change escaping pattern from \1234 to \#1234#

### DIFF
--- a/CDMarkdownKitTests/TestEscape.swift
+++ b/CDMarkdownKitTests/TestEscape.swift
@@ -36,4 +36,33 @@ final class TestEscape: XCTestCase {
         let parsed = parser.parse("\\# Hello")
         XCTAssertEqual(parsed.string, "# Hello")
     }
+
+    func testEscapedSyntax() throws {
+        let parser = getParser()
+
+        let parsed = parser.parse("\\`\\`\\`\nHello\\`\\`\\`")
+        XCTAssertEqual(parsed.string, "```\nHello```")
+    }
+
+    func testEscapedCode() throws {
+        let parser = getParser()
+
+        let parsed = parser.parse("Hello \\`Hi\\\\nABC\\`")
+        XCTAssertEqual(parsed.string, "Hello `Hi\\nABC`")
+    }
+
+
+    func testUnescapeInSyntax() throws {
+        let parser = getParser()
+
+        let parsed = parser.parse("```\nHello\\nthis should not trigger a (un-)escape```")
+        XCTAssertEqual(parsed.string, "Hello\\nthis should not trigger a (un-)escape")
+    }
+
+    func testUnescapeQuoteInSyntax() throws {
+        let parser = getParser()
+
+        let parsed = parser.parse("```\n> This should be left as is```")
+        XCTAssertEqual(parsed.string, "> This should be left as is")
+    }
 }

--- a/Source/CDMarkdownEscaping.swift
+++ b/Source/CDMarkdownEscaping.swift
@@ -51,7 +51,7 @@ open class CDMarkdownEscaping: CDMarkdownElement {
         // escape one character
         let matchString = attributedString.attributedSubstring(from: range).string
         if let escapedString = [UInt16](matchString.utf16).first
-            .flatMap({ (value: UInt16) -> String in String(format: "%04x",
+            .flatMap({ (value: UInt16) -> String in String(format: "#%04x#",
                                                            value) }) {
             attributedString.replaceCharacters(in: range,
                                                with: escapedString)

--- a/Source/CDMarkdownUnescaping.swift
+++ b/Source/CDMarkdownUnescaping.swift
@@ -33,7 +33,7 @@
 
 open class CDMarkdownUnescaping: CDMarkdownElement {
 
-    fileprivate static let regex = ["\\\\[0-9a-z]{4}"]
+    fileprivate static let regex = ["\\\\#[0-9a-f]{4}#"]
     open var enabled: Bool = true
 
     open var regex: [String] {
@@ -46,7 +46,7 @@ open class CDMarkdownUnescaping: CDMarkdownElement {
 
     open func match(_ match: NSTextCheckingResult,
                     attributedString: NSMutableAttributedString) {
-        let range = NSRange(location: match.range.location + 1,
+        let range = NSRange(location: match.range.location + 2,
                             length: 4)
         let matchString = attributedString.attributedSubstring(from: range).string
         guard let unescapedString = matchString.unescapeUTF16() else { return }


### PR DESCRIPTION
Currently escaping works in this order:
1. code escaping (`` `...` ``) -> escaped as base64 inside of the backticks
2. character escaping (`\x`) -> escaped as `\{4 byte hex representation`, e.g. `\0060`)

Unescaping works in this order
1. code unescaping (`` `...` ``) -> match the backticks and decode base64
2. syntax unescaping (` ``` ... ``` `)  -> match the backticks and decode base64
3. character unescaping (`\x`) -> match `\[0-9a-z]{4}` -> convert the 4 byte hex representation back to a character

The problem here is that a code or syntax block could potentially contain a pattern like `\abcd` which would be unescaped by number 3 above.
Changing the order of the unescape is not as easy as it sounds, as escaped backticks would now be rendered as code/syntax blocks again.

Solution for now: Change the pattern of the character escaping to be a bit more unique to lower the chances that this is accidentally included in a code or syntax block. Also the original code matched for `[0-9a-z]` which does not make sense, given that hexadecimal representation is only `[0-9a-f]`.

Alternatively we can exclude the backticks from character unescaping, reorder the unescaping so that characters are unescaped first and introduce another unescaping class for just the backticks. Currently I decided against this approach.