### PR TITLE
Only create NSRegularExpression objects once

### DIFF
--- a/Source/CDMarkdownAutomaticLink.swift
+++ b/Source/CDMarkdownAutomaticLink.swift
@@ -33,7 +33,7 @@
 
 open class CDMarkdownAutomaticLink: CDMarkdownLink {
 
-    open override func regularExpressions() throws -> [NSRegularExpression] {
+    open override func getRegularExpressions() throws -> [NSRegularExpression] {
         return try [NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)]
     }
 

--- a/Source/CDMarkdownBold.swift
+++ b/Source/CDMarkdownBold.swift
@@ -43,9 +43,10 @@ open class CDMarkdownBold: CDMarkdownCommonElement {
     open var underlineStyle: NSUnderlineStyle?
     open var enabled: Bool = true
 
-    open var regex: [String] {
-        return CDMarkdownBold.regex
-    }
+    lazy open var regularExpressions: [NSRegularExpression] = {
+        // swiftlint:disable:next force_try
+        return try! CDMarkdownBold.regex.map { try NSRegularExpression(pattern: $0, options: []) }
+    }()
 
     public init(font: CDFont? = nil,
                 customBoldFont: CDFont? = nil,

--- a/Source/CDMarkdownCode.swift
+++ b/Source/CDMarkdownCode.swift
@@ -43,9 +43,10 @@ open class CDMarkdownCode: CDMarkdownCommonElement {
     open var underlineStyle: NSUnderlineStyle?
     open var enabled: Bool = true
 
-    open var regex: [String] {
-        return CDMarkdownCode.regex
-    }
+    lazy open var regularExpressions: [NSRegularExpression] = {
+        // swiftlint:disable:next force_try
+        return try! CDMarkdownCode.regex.map { try NSRegularExpression(pattern: $0, options: []) }
+    }()
 
     public init(font: CDFont? = CDFont(name: "Menlo-Regular", size: 12),
                 color: CDColor? = CDColor.codeTextRed(),

--- a/Source/CDMarkdownCodeEscaping.swift
+++ b/Source/CDMarkdownCodeEscaping.swift
@@ -36,13 +36,10 @@ open class CDMarkdownCodeEscaping: CDMarkdownElement {
     fileprivate static let regex = ["(?<!\\\\)(?:\\\\\\\\)*+(`+)(.*?[^`].*?)(\\1)(?!`)"]
     open var enabled: Bool = true
 
-    open var regex: [String] {
-        return CDMarkdownCodeEscaping.regex
-    }
-
-    open func regularExpressions() throws -> [NSRegularExpression] {
-        return try regex.map { try NSRegularExpression(pattern: $0, options: .dotMatchesLineSeparators) }
-    }
+    lazy open var regularExpressions: [NSRegularExpression] = {
+        // swiftlint:disable:next force_try
+        return try! CDMarkdownCodeEscaping.regex.map { try NSRegularExpression(pattern: $0, options: [.dotMatchesLineSeparators]) }
+    }()
 
     open func match(_ match: NSTextCheckingResult,
                     attributedString: NSMutableAttributedString) {

--- a/Source/CDMarkdownCommonElement.swift
+++ b/Source/CDMarkdownCommonElement.swift
@@ -41,14 +41,8 @@ public protocol CDMarkdownCommonElement: CDMarkdownElement, CDMarkdownStyle {
 
 public extension CDMarkdownCommonElement {
 
-    func regularExpressions() throws -> [NSRegularExpression] {
-        return try regex.map { try NSRegularExpression(pattern: $0, options: []) }
-    }
-
-    func addAttributes(_ attributedString: NSMutableAttributedString,
-                       range: NSRange) {
-        attributedString.addAttributes(attributes,
-                                       range: range)
+    func addAttributes(_ attributedString: NSMutableAttributedString, range: NSRange) {
+        attributedString.addAttributes(attributes, range: range)
     }
 
     func match(_ match: NSTextCheckingResult, attributedString: NSMutableAttributedString) {

--- a/Source/CDMarkdownElement.swift
+++ b/Source/CDMarkdownElement.swift
@@ -30,10 +30,9 @@ import Foundation
 // The base protocol for all Markdown Elements, it handles parsing through regex.
 public protocol CDMarkdownElement: AnyObject {
 
-    var regex: [String] { get }
+    var regularExpressions: [NSRegularExpression] { get }
     var enabled: Bool { get set }
 
-    func regularExpressions() throws -> [NSRegularExpression]
     func parse(_ attributedString: NSMutableAttributedString)
     func match(_ match: NSTextCheckingResult,
                attributedString: NSMutableAttributedString)
@@ -43,23 +42,20 @@ public extension CDMarkdownElement {
 
     func parse(_ attributedString: NSMutableAttributedString) {
         var location = 0
-        do {
-            let regExpressions = try regularExpressions()
 
-            for regex in regExpressions {
-                location = 0
-                while let regexMatch =
-                        regex.firstMatch(in: attributedString.string,
-                                         options: .withoutAnchoringBounds,
-                                         range: NSRange(location: location,
-                                                        length: attributedString.length - location)) {
-                    let oldLength = attributedString.length
-                    match(regexMatch,
-                          attributedString: attributedString)
-                    let newLength = attributedString.length
-                    location = regexMatch.range.location + regexMatch.range.length + newLength - oldLength
-                }
+        for regex in regularExpressions {
+            location = 0
+            while let regexMatch =
+                    regex.firstMatch(in: attributedString.string,
+                                     options: .withoutAnchoringBounds,
+                                     range: NSRange(location: location,
+                                                    length: attributedString.length - location)) {
+
+                let oldLength = attributedString.length
+                match(regexMatch, attributedString: attributedString)
+                let newLength = attributedString.length
+                location = regexMatch.range.location + regexMatch.range.length + newLength - oldLength
             }
-        } catch { }
+        }
     }
 }

--- a/Source/CDMarkdownEscaping.swift
+++ b/Source/CDMarkdownEscaping.swift
@@ -36,13 +36,10 @@ open class CDMarkdownEscaping: CDMarkdownElement {
     fileprivate static let regex = ["\\\\."]
     open var enabled: Bool = true
 
-    open var regex: [String] {
-        return CDMarkdownEscaping.regex
-    }
-
-    open func regularExpressions() throws -> [NSRegularExpression] {
-        return try regex.map { try NSRegularExpression(pattern: $0, options: .dotMatchesLineSeparators) }
-    }
+    lazy open var regularExpressions: [NSRegularExpression] = {
+        // swiftlint:disable:next force_try
+        return try! CDMarkdownEscaping.regex.map { try NSRegularExpression(pattern: $0, options: [.dotMatchesLineSeparators]) }
+    }()
 
     open func match(_ match: NSTextCheckingResult,
                     attributedString: NSMutableAttributedString) {

--- a/Source/CDMarkdownHeader.swift
+++ b/Source/CDMarkdownHeader.swift
@@ -33,7 +33,8 @@
 
 open class CDMarkdownHeader: CDMarkdownLevelElement {
 
-    fileprivate static let regex = ["^\\s*(#{1,%@})\\s+(.+)$\n*"]
+    fileprivate static let regex = "^\\s*(#{1,%@})\\s+(.+)$\n*"
+
     fileprivate struct CDMarkdownHeadingHashes {
         static let one   = 9
         static let two   = 5
@@ -54,10 +55,13 @@ open class CDMarkdownHeader: CDMarkdownLevelElement {
     open var underlineStyle: NSUnderlineStyle?
     open var enabled: Bool = true
 
-    open var regex: [String] {
+    lazy open var regularExpressions: [NSRegularExpression] = {
         let level: String = maxLevel > 0 ? "\(maxLevel)" : ""
-        return [String(format: CDMarkdownHeader.regex.first!, level)]
-    }
+        let formattedRegex = String(format: CDMarkdownHeader.regex, level)
+
+        // swiftlint:disable:next force_try
+        return [try! NSRegularExpression(pattern: formattedRegex, options: .anchorsMatchLines)]
+    }()
 
     public init(font: CDFont? = CDFont.boldSystemFont(ofSize: 12),
                 maxLevel: Int = 0,

--- a/Source/CDMarkdownImage.swift
+++ b/Source/CDMarkdownImage.swift
@@ -34,7 +34,6 @@
 #if os(iOS) || os(macOS) || os(tvOS)
 
 open class CDMarkdownImage: CDMarkdownLinkElement {
-
     fileprivate static let regex = ["[!{1}]\\[([^\\[]*?)\\]\\(([^\\)]*)\\)"]
 
     open var font: CDFont?
@@ -46,13 +45,10 @@ open class CDMarkdownImage: CDMarkdownLinkElement {
     open var underlineStyle: NSUnderlineStyle?
     open var enabled: Bool = true
 
-    open var regex: [String] {
-        return CDMarkdownImage.regex
-    }
-
-    open func regularExpressions() throws -> [NSRegularExpression] {
-        return try regex.map { try NSRegularExpression(pattern: $0, options: .dotMatchesLineSeparators) }
-    }
+    lazy open var regularExpressions: [NSRegularExpression] = {
+        // swiftlint:disable:next force_try
+        return try! CDMarkdownImage.regex.map { try NSRegularExpression(pattern: $0, options: []) }
+    }()
 
     public init(font: CDFont? = nil,
                 color: CDColor? = CDColor.blue,

--- a/Source/CDMarkdownItalic.swift
+++ b/Source/CDMarkdownItalic.swift
@@ -43,9 +43,10 @@ open class CDMarkdownItalic: CDMarkdownCommonElement {
     open var underlineStyle: NSUnderlineStyle?
     open var enabled: Bool = true
 
-    open var regex: [String] {
-        return CDMarkdownItalic.regex
-    }
+    lazy open var regularExpressions: [NSRegularExpression] = {
+        // swiftlint:disable:next force_try
+        return try! CDMarkdownItalic.regex.map { try NSRegularExpression(pattern: $0, options: []) }
+    }()
 
     public init(font: CDFont? = nil,
                 customItalicFont: CDFont? = nil,

--- a/Source/CDMarkdownLevelElement.swift
+++ b/Source/CDMarkdownLevelElement.swift
@@ -52,11 +52,6 @@ public protocol CDMarkdownLevelElement: CDMarkdownElement, CDMarkdownStyle {
 
 public extension CDMarkdownLevelElement {
 
-    func regularExpressions() throws -> [NSRegularExpression] {
-        return try [NSRegularExpression(pattern: regex.first!,
-                                       options: .anchorsMatchLines)]
-    }
-
     func addFullAttributes(_ attributedString: NSMutableAttributedString,
                            range: NSRange,
                            level: Int) {}

--- a/Source/CDMarkdownLink.swift
+++ b/Source/CDMarkdownLink.swift
@@ -43,13 +43,15 @@ open class CDMarkdownLink: CDMarkdownLinkElement {
     open var underlineStyle: NSUnderlineStyle?
     open var enabled: Bool = true
 
-    open var regex: [String] {
-        return CDMarkdownLink.regex
+    // Use function here to allow overriding in subclass
+    open func getRegularExpressions() throws -> [NSRegularExpression] {
+        return try CDMarkdownLink.regex.map { try NSRegularExpression(pattern: $0, options: .dotMatchesLineSeparators) }
     }
 
-    open func regularExpressions() throws -> [NSRegularExpression] {
-        return try regex.map { try NSRegularExpression(pattern: $0, options: .dotMatchesLineSeparators) }
-    }
+    lazy open var regularExpressions: [NSRegularExpression] = {
+        // swiftlint:disable:next force_try
+        return try! self.getRegularExpressions()
+    }()
 
     public init(font: CDFont? = nil,
                 color: CDColor? = CDColor.blue,

--- a/Source/CDMarkdownList.swift
+++ b/Source/CDMarkdownList.swift
@@ -33,7 +33,7 @@
 
 open class CDMarkdownList: CDMarkdownLevelElement {
 
-    fileprivate static let regex = ["^\\s*([\\*\\+\\-]{1,%@})[ \t]+(.+)$"]
+    fileprivate static let regex = "^\\s*([\\*\\+\\-]{1,%@})[ \t]+(.+)$"
 
     open var font: CDFont?
     open var maxLevel: Int
@@ -46,11 +46,13 @@ open class CDMarkdownList: CDMarkdownLevelElement {
     open var underlineStyle: NSUnderlineStyle?
     open var enabled: Bool = true
 
-    open var regex: [String] {
+    lazy open var regularExpressions: [NSRegularExpression] = {
         let level: String = maxLevel > 0 ? "\(maxLevel)" : ""
-        return [String(format: CDMarkdownList.regex.first!,
-                      level)]
-    }
+        let formattedRegex = String(format: CDMarkdownList.regex, level)
+
+        // swiftlint:disable:next force_try
+        return [try! NSRegularExpression(pattern: formattedRegex, options: .anchorsMatchLines)]
+    }()
 
     public init(font: CDFont? = nil,
                 maxLevel: Int = 0,

--- a/Source/CDMarkdownQuote.swift
+++ b/Source/CDMarkdownQuote.swift
@@ -33,7 +33,7 @@
 
 open class CDMarkdownQuote: CDMarkdownLevelElement {
 
-    fileprivate static let regex = ["^(\\>{1,%@})\\s*(.+)$"]
+    fileprivate static let regex = "^(\\>{1,%@})\\s*(.+)$"
 
     open var font: CDFont?
     open var maxLevel: Int
@@ -46,11 +46,13 @@ open class CDMarkdownQuote: CDMarkdownLevelElement {
     open var underlineStyle: NSUnderlineStyle?
     open var enabled: Bool = true
 
-    open var regex: [String] {
+    lazy open var regularExpressions: [NSRegularExpression] = {
         let level: String = maxLevel > 0 ? "\(maxLevel)" : ""
-        return [String(format: CDMarkdownQuote.regex.first!,
-                      level)]
-    }
+        let formattedRegex = String(format: CDMarkdownQuote.regex, level)
+
+        // swiftlint:disable:next force_try
+        return [try! NSRegularExpression(pattern: formattedRegex, options: .anchorsMatchLines)]
+    }()
 
     public init(font: CDFont? = nil,
                 maxLevel: Int = 0,

--- a/Source/CDMarkdownStrikethrough.swift
+++ b/Source/CDMarkdownStrikethrough.swift
@@ -45,9 +45,10 @@ open class CDMarkdownStrikethrough: CDMarkdownCommonElement {
     open var underlineStyle: NSUnderlineStyle?
     open var enabled: Bool = true
 
-    open var regex: [String] {
-        return CDMarkdownStrikethrough.regex
-    }
+    lazy open var regularExpressions: [NSRegularExpression] = {
+        // swiftlint:disable:next force_try
+        return try! CDMarkdownStrikethrough.regex.map { try NSRegularExpression(pattern: $0, options: []) }
+    }()
 
     public init(font: CDFont? = nil,
                 color: CDColor? = nil,

--- a/Source/CDMarkdownSyntax.swift
+++ b/Source/CDMarkdownSyntax.swift
@@ -43,9 +43,10 @@ open class CDMarkdownSyntax: CDMarkdownCommonElement {
     open var underlineStyle: NSUnderlineStyle?
     open var enabled: Bool = true
 
-    open var regex: [String] {
-        return CDMarkdownSyntax.regex
-    }
+    lazy open var regularExpressions: [NSRegularExpression] = {
+        // swiftlint:disable:next force_try
+        return try! CDMarkdownSyntax.regex.map { try NSRegularExpression(pattern: $0, options: []) }
+    }()
 
     public init(font: CDFont? = CDFont(name: "Menlo-Regular", size: 12),
                 color: CDColor? = CDColor.syntaxTextGray(),

--- a/Source/CDMarkdownUnescaping.swift
+++ b/Source/CDMarkdownUnescaping.swift
@@ -36,13 +36,10 @@ open class CDMarkdownUnescaping: CDMarkdownElement {
     fileprivate static let regex = ["\\\\#[0-9a-f]{4}#"]
     open var enabled: Bool = true
 
-    open var regex: [String] {
-        return CDMarkdownUnescaping.regex
-    }
-
-    open func regularExpressions() throws -> [NSRegularExpression] {
-        return try regex.map { try NSRegularExpression(pattern: $0, options: .dotMatchesLineSeparators) }
-    }
+    lazy open var regularExpressions: [NSRegularExpression] = {
+        // swiftlint:disable:next force_try
+        return try! CDMarkdownUnescaping.regex.map { try NSRegularExpression(pattern: $0, options: [.dotMatchesLineSeparators]) }
+    }()
 
     open func match(_ match: NSTextCheckingResult,
                     attributedString: NSMutableAttributedString) {


### PR DESCRIPTION
No need to create an NSRegularExpression on each call, it won't change in between calls anyway.