### PR TITLE
Specify the escapable characters

### DIFF
--- a/CDMarkdownKitTests/TestEscape.swift
+++ b/CDMarkdownKitTests/TestEscape.swift
@@ -65,4 +65,11 @@ final class TestEscape: XCTestCase {
         let parsed = parser.parse("```\n> This should be left as is```")
         XCTAssertEqual(parsed.string, "> This should be left as is")
     }
+
+    func testNonEscapableChars() throws {
+        let parser = getParser()
+
+        let parsed = parser.parse("\\A\\B\\C\\a\\b\\c\\1\\2\\3")
+        XCTAssertEqual(parsed.string, "\\A\\B\\C\\a\\b\\c\\1\\2\\3")
+    }
 }

--- a/Source/CDMarkdownEscaping.swift
+++ b/Source/CDMarkdownEscaping.swift
@@ -33,7 +33,7 @@
 
 open class CDMarkdownEscaping: CDMarkdownElement {
 
-    fileprivate static let regex = ["\\\\."]
+    fileprivate static let regex = ["\\\\[\\*|#|`|\\-|_|~|\\\\|\\(|\\)|\\[|\\]|\\+]"]
     open var enabled: Bool = true
 
     lazy open var regularExpressions: [NSRegularExpression] = {


### PR DESCRIPTION
Instead of matching any characters, match the characters that are escapable.

Should fix https://github.com/nextcloud/talk-ios/issues/1445