### PR TITLE
fix(strikethrough): Improve strikethrough recognition

### DIFF
--- a/CDMarkdownKitTests/TestStrikethrough.swift
+++ b/CDMarkdownKitTests/TestStrikethrough.swift
@@ -34,13 +34,33 @@ final class TestStrikethrough: XCTestCase {
         parsed = parser.parse("~Test~")
         XCTAssertEqual(parsed.string, "Test")
         XCTAssertTrue(TestHelpers.isStrikethrough(testString: parsed, at: 0))
+
+        // The result is expected, since parser.trimLeadingWhitespaces is true by default
+        parsed = parser.parse(" ~Test~ ")
+        XCTAssertEqual(parsed.string, "Test ")
+        XCTAssertTrue(TestHelpers.isStrikethrough(testString: parsed, at: 1))
+
+        parser.trimLeadingWhitespaces = false
+        parsed = parser.parse(" ~Test~ ")
+        XCTAssertEqual(parsed.string, " Test ")
+        XCTAssertTrue(TestHelpers.isStrikethrough(testString: parsed, at: 3))
     }
 
     func testNonStrikethrough() throws {
         let parser = CDMarkdownParser()
 
-        let parsed = parser.parse("~~Test~")
+        var parsed = parser.parse("~~Test~")
         XCTAssertEqual(parsed.string, "Test~")
         XCTAssertFalse(TestHelpers.isStrikethrough(testString: parsed, at: 0))
+
+        parsed = parser.parse("~Test ~Test")
+        XCTAssertEqual(parsed.string, "~Test ~Test")
+        XCTAssertFalse(TestHelpers.isStrikethrough(testString: parsed, at: 0))
+        XCTAssertFalse(TestHelpers.isStrikethrough(testString: parsed, at: 4))
+
+        parsed = parser.parse("~ Test~ Test")
+        XCTAssertEqual(parsed.string, "~ Test~ Test")
+        XCTAssertFalse(TestHelpers.isStrikethrough(testString: parsed, at: 0))
+        XCTAssertFalse(TestHelpers.isStrikethrough(testString: parsed, at: 4))
     }
 }

--- a/Source/CDMarkdownStrikethrough.swift
+++ b/Source/CDMarkdownStrikethrough.swift
@@ -33,7 +33,7 @@
 
 open class CDMarkdownStrikethrough: CDMarkdownCommonElement {
 
-    fileprivate static let regex = ["()(~{1,2})(.*?)(\\2)"]
+    fileprivate static let regex = ["()(~~(?!\\s))(.*?)((?<!\\s)~~)", "()(~(?!\\s))(.*?)((?<!\\s)~)"]
 
     open var font: CDFont?
     open var color: CDColor?


### PR DESCRIPTION
E.g.

```
 ~test~
 
 ~13 ~14
 
 ~ 13~ 14
 
~ asd ~
 
 
~test~

~test ~test

~ test~ test
```

Renders as:

 ~test~
 
 ~13 ~14
 
 ~ 13~ 14
 
~ asd ~
 
 
~test~

~test ~test

~ test~ test