### PR TITLE
perf(escaping): Remove catastrophic backtracking regex for code escape

### DIFF
--- a/CDMarkdownKitTests/TestCode.swift
+++ b/CDMarkdownKitTests/TestCode.swift
@@ -44,6 +44,18 @@ final class TestCode: XCTestCase {
         XCTAssertTrue(TestHelpers.isMonospaced(testString: parsed, at: 0))
     }
 
+
+    func testCodeMultiple() throws {
+        let parser = getParser()
+
+        let parsed = parser.parse("`test` abc `test` abc")
+        XCTAssertEqual(parsed.string, "test abc test abc")
+        XCTAssertTrue(TestHelpers.isMonospaced(testString: parsed, at: 2))
+        XCTAssertFalse(TestHelpers.isMonospaced(testString: parsed, at: 6))
+        XCTAssertTrue(TestHelpers.isMonospaced(testString: parsed, at: 11))
+        XCTAssertFalse(TestHelpers.isMonospaced(testString: parsed, at: 15))
+    }
+
     func testCodeSentence() throws {
         let parser = getParser()
 

--- a/CDMarkdownKitTests/TestSyntax.swift
+++ b/CDMarkdownKitTests/TestSyntax.swift
@@ -112,4 +112,12 @@ final class TestSyntax: XCTestCase {
         XCTAssertFalse(TestHelpers.anyBold(testString: parsed))
         XCTAssertFalse(TestHelpers.anyItalic(testString: parsed))
     }
+
+    func testSyntaxOnlyStart() throws {
+        let parser = getParser()
+
+        let parsed = parser.parse("```\nsyntax\n")
+        XCTAssertEqual(parsed.string, "```\nsyntax\n")
+        XCTAssertFalse(TestHelpers.isMonospaced(testString: parsed, at: 4))
+    }
 }

--- a/Source/CDMarkdownCodeEscaping.swift
+++ b/Source/CDMarkdownCodeEscaping.swift
@@ -33,12 +33,12 @@
 
 open class CDMarkdownCodeEscaping: CDMarkdownElement {
 
-    fileprivate static let regex = ["(?<!\\\\)(?:\\\\\\\\)*+(`+)(.*?[^`].*?)(\\1)(?!`)"]
+    fileprivate static let regex = ["(?<!\\\\)(?:\\\\\\\\)*+(`+(?!`))([\\s\\S]*?)(\\1)"]
     open var enabled: Bool = true
 
     lazy open var regularExpressions: [NSRegularExpression] = {
         // swiftlint:disable:next force_try
-        return try! CDMarkdownCodeEscaping.regex.map { try NSRegularExpression(pattern: $0, options: [.dotMatchesLineSeparators]) }
+        return try! CDMarkdownCodeEscaping.regex.map { try NSRegularExpression(pattern: $0, options: []) }
     }()
 
     open func match(_ match: NSTextCheckingResult,


### PR DESCRIPTION
**Performance before**
MM: 104.511237791 seconds
MM: 104.49352295899999 seconds
MM: 105.008809959 seconds

**Performance after**
MM: 0.34015025 seconds
MM: 0.331338208 seconds
MM: 0.351607875 seconds

**Code for performance test**

````swift
func testTime() throws {
        let clock = ContinuousClock()
        let parser = getParser()

        let result = clock.measure {
            for _ in 0 ..< 100
            {
                _ = parser.parse("""
```
                             Name              Application ID               Version                  Branch      Installation
                             AnyDesk           com.anydesk.Anydesk          6.4.0                    stable      user
                             draw.io           com.jgraph.drawio.desktop    26.0.4                   stable      user
                             Nextcloud Desktop …oud.desktopclient.nextcloud 3.15.3                   stable      user
                             0 A.D.            com.play0ad.zeroad           0.0.26                   stable      user
                             Visual Studio Co… com.visualstudio.code        1.96.4                   stable      user
                             Floorp            one.ablaze.floorp            11.23.0                  stable      user
                             Freedesktop Plat… org.freedesktop.Platform     freedesktop-sdk-22.08.27 22.08       user
                             Freedesktop Plat… org.freedesktop.Platform     freedesktop-sdk-24.08.11 24.08       user
                             Mesa              …desktop.Platform.GL.default 24.0.9                   22.08       user
                             Mesa (Extra)      …desktop.Platform.GL.default 24.0.9                   22.08-extra user
                             Mesa              …desktop.Platform.GL.default 24.3.1                   23.08       user
                             Mesa (Extra)      …desktop.Platform.GL.default 24.3.1                   23.08-extra user
                             Mesa              …desktop.Platform.GL.default 24.3.4                   24.08       user
                             Mesa (Extra)      …desktop.Platform.GL.default 24.3.4                   24.08extra  user
                             Intel             …esktop.Platform.VAAPI.Intel                          22.08       user
                             Intel VAAPI driv… …esktop.Platform.VAAPI.Intel                          23.08       user
                             Intel VAAPI driv… …esktop.Platform.VAAPI.Intel                          24.08       user
                             FFmpeg extension… …esktop.Platform.ffmpeg-full                          24.08       user
                             openh264          …eedesktop.Platform.openh264 2.1.0                    2.2.0       user
                             openh264          …eedesktop.Platform.openh264 2.4.1                    2.4.1       user
                             Freedesktop SDK   org.freedesktop.Sdk          freedesktop-sdk-22.08.27 22.08       user
                             Freedesktop SDK   org.freedesktop.Sdk          freedesktop-sdk-23.08.27 23.08       user
                             Freedesktop SDK   org.freedesktop.Sdk          freedesktop-sdk-24.08.10 24.08       user
                             Evolution         org.gnome.Evolution          3.54.3                   stable      user
                             GNOME Applicatio… org.gnome.Platform                                    47          user
                             Pop Gtk theme     org.gtk.Gtk3theme.Pop-dark                            3.22        user
                             KDE Application … org.kde.Platform                                      5.15-24.08  user
                             KDE Application … org.kde.Platform                                      6.7         user
                             KDE Application … org.kde.Platform                                      6.8         user
                             QGnomePlatform    …latformTheme.QGnomePlatform                          5.15-24.08  user
                             QAdwaitaDecorati… …oration.QAdwaitaDecorations                          5.15-24.08  user
                             QAdwaitaDecorati… …oration.QAdwaitaDecorations                          6.7         user
                             KeePassXC         org.keepassxc.KeePassXC      2.7.9                    stable      user
                             Signal Desktop    org.signal.Signal            7.41.0                   stable      user
                             Wireshark         org.wireshark.Wireshark      4.4.3                    stable      user
""")
            }
        }

        print("MM: \(result)")
    }
````

(note the non-closing three-backticks)

**How to test manually**

1. Post the following message
   ````
   ```
                             Name              Application ID               Version                  Branch      Installation
                             AnyDesk           com.anydesk.Anydesk          6.4.0                    stable      user
                             draw.io           com.jgraph.drawio.desktop    26.0.4                   stable      user
                             Nextcloud Desktop …oud.desktopclient.nextcloud 3.15.3                   stable      user
                             0 A.D.            com.play0ad.zeroad           0.0.26                   stable      user
                             Visual Studio Co… com.visualstudio.code        1.96.4                   stable      user
                             Floorp            one.ablaze.floorp            11.23.0                  stable      user
                             Freedesktop Plat… org.freedesktop.Platform     freedesktop-sdk-22.08.27 22.08       user
                             Freedesktop Plat… org.freedesktop.Platform     freedesktop-sdk-24.08.11 24.08       user
                             Mesa              …desktop.Platform.GL.default 24.0.9                   22.08       user
                             Mesa (Extra)      …desktop.Platform.GL.default 24.0.9                   22.08-extra user
                             Mesa              …desktop.Platform.GL.default 24.3.1                   23.08       user
                             Mesa (Extra)      …desktop.Platform.GL.default 24.3.1                   23.08-extra user
                             Mesa              …desktop.Platform.GL.default 24.3.4                   24.08       user
                             Mesa (Extra)      …desktop.Platform.GL.default 24.3.4                   24.08extra  user
                             Intel             …esktop.Platform.VAAPI.Intel                          22.08       user
                             Intel VAAPI driv… …esktop.Platform.VAAPI.Intel                          23.08       user
                             Intel VAAPI driv… …esktop.Platform.VAAPI.Intel                          24.08       user
                             FFmpeg extension… …esktop.Platform.ffmpeg-full                          24.08       user
                             openh264          …eedesktop.Platform.openh264 2.1.0                    2.2.0       user
                             openh264          …eedesktop.Platform.openh264 2.4.1                    2.4.1       user
                             Freedesktop SDK   org.freedesktop.Sdk          freedesktop-sdk-22.08.27 22.08       user
                             Freedesktop SDK   org.freedesktop.Sdk          freedesktop-sdk-23.08.27 23.08       user
                             Freedesktop SDK   org.freedesktop.Sdk          freedesktop-sdk-24.08.10 24.08       user
                             Evolution         org.gnome.Evolution          3.54.3                   stable      user
                             GNOME Applicatio… org.gnome.Platform                                    47          user
                             Pop Gtk theme     org.gtk.Gtk3theme.Pop-dark                            3.22        user
                             KDE Application … org.kde.Platform                                      5.15-24.08  user
                             KDE Application … org.kde.Platform                                      6.7         user
                             KDE Application … org.kde.Platform                                      6.8         user
                             QGnomePlatform    …latformTheme.QGnomePlatform                          5.15-24.08  user
                             QAdwaitaDecorati… …oration.QAdwaitaDecorations                          5.15-24.08  user
                             QAdwaitaDecorati… …oration.QAdwaitaDecorations                          6.7         user
                             KeePassXC         org.keepassxc.KeePassXC      2.7.9                    stable      user
                             Signal Desktop    org.signal.Signal            7.41.0                   stable      user
                             Wireshark         org.wireshark.Wireshark      4.4.3                    stable      user
   ````

2. Try to scroll the conversation list, when this message is the last message (it hangs)
3. Try to enter a conversation with that message (it shows a spinner while opening the conversation)

Info on catastrophic backtracking: https://www.regular-expressions.info/possessive.html