### PR TITLE
Fix markdown parsing in edge cases / Add task support

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -24,12 +24,22 @@ jobs:
 
     env:
       WORKSPACE: CDMarkdownKit.xcworkspace
-      DESTINATION: platform=iOS Simulator,name=iPhone 16,OS=18.0
+      DESTINATION: platform=iOS Simulator,name=iPhone 16,OS=18.5
       SCHEME: "CDMarkdownKit iOS"
 
     steps:
     - name: Checkout app
-      uses: actions/checkout@v3    
+      uses: actions/checkout@v3
+
+    - name: Setup Xcode
+      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+      with:
+        xcode-version: '26.2'
+
+    - name: Install iOS 18.5
+      run: |
+        xcrun simctl list > /dev/null # Required to prevent the next command from sometimes not working
+        xcodebuild -downloadPlatform iOS -buildVersion 18.5
 
     - name: Build & Test CDMarkdownKit iOS
       run: |

--- a/CDMarkdownKit.xcodeproj/project.pbxproj
+++ b/CDMarkdownKit.xcodeproj/project.pbxproj
@@ -17,6 +17,11 @@
 		1F8156CB2F59ECA500D25526 /* TestLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8156CA2F59ECA500D25526 /* TestLink.swift */; };
 		1F8538492ADFE12E0011FE81 /* TestEscape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8538482ADFE12E0011FE81 /* TestEscape.swift */; };
 		1F9A797D2A98B4AF00E153E3 /* TestHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9A797C2A98B4AF00E153E3 /* TestHeader.swift */; };
+		1FAFDC352CAB451700F198C3 /* TestTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FAFDC342CAB451700F198C3 /* TestTask.swift */; };
+		1FAFDC372CAB45CA00F198C3 /* CDMarkdownTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FAFDC362CAB45CA00F198C3 /* CDMarkdownTask.swift */; };
+		1FAFDC382CAB45CA00F198C3 /* CDMarkdownTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FAFDC362CAB45CA00F198C3 /* CDMarkdownTask.swift */; };
+		1FAFDC392CAB45CA00F198C3 /* CDMarkdownTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FAFDC362CAB45CA00F198C3 /* CDMarkdownTask.swift */; };
+		1FAFDC3A2CAB45CA00F198C3 /* CDMarkdownTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FAFDC362CAB45CA00F198C3 /* CDMarkdownTask.swift */; };
 		5F0AD09521063D36007B718F /* CDImage+CDMarkdownKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0AD09421063D36007B718F /* CDImage+CDMarkdownKit.swift */; };
 		5F0AD09621063D36007B718F /* CDImage+CDMarkdownKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0AD09421063D36007B718F /* CDImage+CDMarkdownKit.swift */; };
 		5F0AD09721063D36007B718F /* CDImage+CDMarkdownKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0AD09421063D36007B718F /* CDImage+CDMarkdownKit.swift */; };
@@ -188,6 +193,8 @@
 		1F8156CA2F59ECA500D25526 /* TestLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestLink.swift; sourceTree = "<group>"; };
 		1F8538482ADFE12E0011FE81 /* TestEscape.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestEscape.swift; sourceTree = "<group>"; };
 		1F9A797C2A98B4AF00E153E3 /* TestHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHeader.swift; sourceTree = "<group>"; };
+		1FAFDC342CAB451700F198C3 /* TestTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestTask.swift; sourceTree = "<group>"; };
+		1FAFDC362CAB45CA00F198C3 /* CDMarkdownTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDMarkdownTask.swift; sourceTree = "<group>"; };
 		5F0AD09421063D36007B718F /* CDImage+CDMarkdownKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CDImage+CDMarkdownKit.swift"; sourceTree = "<group>"; };
 		B205C6651FC129EB00E74CBA /* CDColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDColor.swift; sourceTree = "<group>"; };
 		B205C66A1FC129FC00E74CBA /* CDFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDFont.swift; sourceTree = "<group>"; };
@@ -291,6 +298,7 @@
 				1F66CB7B2A8FBC8F00FC7BA7 /* TestCode.swift */,
 				1F8538482ADFE12E0011FE81 /* TestEscape.swift */,
 				1F9A797C2A98B4AF00E153E3 /* TestHeader.swift */,
+				1FAFDC342CAB451700F198C3 /* TestTask.swift */,
 				1F02B8592A90D60D0023148B /* TestSyntax.swift */,
 				1F549C1A2D3EF78C00E9AA9E /* TestStrikethrough.swift */,
 				1F8156CA2F59ECA500D25526 /* TestLink.swift */,
@@ -401,6 +409,7 @@
 				B2B366191F324DE90078B962 /* CDMarkdownQuote.swift */,
 				B2CAD0A028FC20150069CA4B /* CDMarkdownStrikethrough.swift */,
 				B2B3661B1F324DE90078B962 /* CDMarkdownSyntax.swift */,
+				1FAFDC362CAB45CA00F198C3 /* CDMarkdownTask.swift */,
 				B2B3663A1F324E040078B962 /* Escaping */,
 			);
 			name = Elements;
@@ -720,6 +729,7 @@
 				1F9A797D2A98B4AF00E153E3 /* TestHeader.swift in Sources */,
 				1F66CB7A2A8FBC1000FC7BA7 /* TestBold.swift in Sources */,
 				1F02B85C2A90D6210023148B /* TestHelpers.swift in Sources */,
+				1FAFDC352CAB451700F198C3 /* TestTask.swift in Sources */,
 				1F66CB7C2A8FBC8F00FC7BA7 /* TestCode.swift in Sources */,
 				1F549C1B2D3EF78C00E9AA9E /* TestStrikethrough.swift in Sources */,
 				1F8156CB2F59ECA500D25526 /* TestLink.swift in Sources */,
@@ -742,6 +752,7 @@
 				B2ACA0A91FBF95A400EABEF6 /* CDMarkdownCodeEscaping.swift in Sources */,
 				B2ACA0AF1FBF95A400EABEF6 /* CDMarkdownCommonElement.swift in Sources */,
 				B2ACA0B01FBF95A400EABEF6 /* CDMarkdownElement.swift in Sources */,
+				1FAFDC3A2CAB45CA00F198C3 /* CDMarkdownTask.swift in Sources */,
 				B2ACA0AA1FBF95A400EABEF6 /* CDMarkdownEscaping.swift in Sources */,
 				B2ACA0A21FBF95A400EABEF6 /* CDMarkdownHeader.swift in Sources */,
 				B267903B2868AC0E00DFAAA5 /* CDMarkdownKit.swift in Sources */,
@@ -786,6 +797,7 @@
 				B2ACA0C21FBF960A00EABEF6 /* CDMarkdownCodeEscaping.swift in Sources */,
 				B2ACA0C81FBF960A00EABEF6 /* CDMarkdownCommonElement.swift in Sources */,
 				B2ACA0C91FBF960A00EABEF6 /* CDMarkdownElement.swift in Sources */,
+				1FAFDC392CAB45CA00F198C3 /* CDMarkdownTask.swift in Sources */,
 				B2ACA0C31FBF960A00EABEF6 /* CDMarkdownEscaping.swift in Sources */,
 				B2ACA0BB1FBF960A00EABEF6 /* CDMarkdownHeader.swift in Sources */,
 				B267903C2868AC0E00DFAAA5 /* CDMarkdownKit.swift in Sources */,
@@ -830,6 +842,7 @@
 				B2ACA0DB1FBF967800EABEF6 /* CDMarkdownCodeEscaping.swift in Sources */,
 				B2ACA0E11FBF967800EABEF6 /* CDMarkdownCommonElement.swift in Sources */,
 				B2ACA0E21FBF967800EABEF6 /* CDMarkdownElement.swift in Sources */,
+				1FAFDC372CAB45CA00F198C3 /* CDMarkdownTask.swift in Sources */,
 				B2ACA0DC1FBF967800EABEF6 /* CDMarkdownEscaping.swift in Sources */,
 				B2ACA0D41FBF967800EABEF6 /* CDMarkdownHeader.swift in Sources */,
 				B267903D2868AC0E00DFAAA5 /* CDMarkdownKit.swift in Sources */,
@@ -874,6 +887,7 @@
 				B2B3662B1F324DE90078B962 /* CDMarkdownCodeEscaping.swift in Sources */,
 				B2B3662C1F324DE90078B962 /* CDMarkdownCommonElement.swift in Sources */,
 				B2B3662D1F324DE90078B962 /* CDMarkdownElement.swift in Sources */,
+				1FAFDC382CAB45CA00F198C3 /* CDMarkdownTask.swift in Sources */,
 				B2B3662E1F324DE90078B962 /* CDMarkdownEscaping.swift in Sources */,
 				B2B366271F324DE90078B962 /* CDMarkdownHeader.swift in Sources */,
 				B267903A2868AC0E00DFAAA5 /* CDMarkdownKit.swift in Sources */,

--- a/CDMarkdownKit.xcodeproj/project.pbxproj
+++ b/CDMarkdownKit.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		1F66CB682A8EB04C00FC7BA7 /* CDMarkdownKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B2B365B71F3245800078B962 /* CDMarkdownKit.framework */; };
 		1F66CB7A2A8FBC1000FC7BA7 /* TestBold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F66CB792A8FBC1000FC7BA7 /* TestBold.swift */; };
 		1F66CB7C2A8FBC8F00FC7BA7 /* TestCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F66CB7B2A8FBC8F00FC7BA7 /* TestCode.swift */; };
+		1F8156CB2F59ECA500D25526 /* TestLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8156CA2F59ECA500D25526 /* TestLink.swift */; };
 		1F8538492ADFE12E0011FE81 /* TestEscape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8538482ADFE12E0011FE81 /* TestEscape.swift */; };
 		1F9A797D2A98B4AF00E153E3 /* TestHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9A797C2A98B4AF00E153E3 /* TestHeader.swift */; };
 		5F0AD09521063D36007B718F /* CDImage+CDMarkdownKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0AD09421063D36007B718F /* CDImage+CDMarkdownKit.swift */; };
@@ -184,6 +185,7 @@
 		1F66CB662A8EB04C00FC7BA7 /* TestItalic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestItalic.swift; sourceTree = "<group>"; };
 		1F66CB792A8FBC1000FC7BA7 /* TestBold.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestBold.swift; sourceTree = "<group>"; };
 		1F66CB7B2A8FBC8F00FC7BA7 /* TestCode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCode.swift; sourceTree = "<group>"; };
+		1F8156CA2F59ECA500D25526 /* TestLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestLink.swift; sourceTree = "<group>"; };
 		1F8538482ADFE12E0011FE81 /* TestEscape.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestEscape.swift; sourceTree = "<group>"; };
 		1F9A797C2A98B4AF00E153E3 /* TestHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHeader.swift; sourceTree = "<group>"; };
 		5F0AD09421063D36007B718F /* CDImage+CDMarkdownKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CDImage+CDMarkdownKit.swift"; sourceTree = "<group>"; };
@@ -291,6 +293,7 @@
 				1F9A797C2A98B4AF00E153E3 /* TestHeader.swift */,
 				1F02B8592A90D60D0023148B /* TestSyntax.swift */,
 				1F549C1A2D3EF78C00E9AA9E /* TestStrikethrough.swift */,
+				1F8156CA2F59ECA500D25526 /* TestLink.swift */,
 			);
 			path = CDMarkdownKitTests;
 			sourceTree = "<group>";
@@ -719,6 +722,7 @@
 				1F02B85C2A90D6210023148B /* TestHelpers.swift in Sources */,
 				1F66CB7C2A8FBC8F00FC7BA7 /* TestCode.swift in Sources */,
 				1F549C1B2D3EF78C00E9AA9E /* TestStrikethrough.swift in Sources */,
+				1F8156CB2F59ECA500D25526 /* TestLink.swift in Sources */,
 				1F02B85A2A90D60D0023148B /* TestSyntax.swift in Sources */,
 				1F66CB672A8EB04C00FC7BA7 /* TestItalic.swift in Sources */,
 			);

--- a/CDMarkdownKit.xcodeproj/project.pbxproj
+++ b/CDMarkdownKit.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		1F66CB7A2A8FBC1000FC7BA7 /* TestBold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F66CB792A8FBC1000FC7BA7 /* TestBold.swift */; };
 		1F66CB7C2A8FBC8F00FC7BA7 /* TestCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F66CB7B2A8FBC8F00FC7BA7 /* TestCode.swift */; };
 		1F8156CB2F59ECA500D25526 /* TestLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8156CA2F59ECA500D25526 /* TestLink.swift */; };
+		1F8156CE2F5AD67F00D25526 /* TestQuotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8156CD2F5AD67F00D25526 /* TestQuotes.swift */; };
 		1F8538492ADFE12E0011FE81 /* TestEscape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8538482ADFE12E0011FE81 /* TestEscape.swift */; };
 		1F9A797D2A98B4AF00E153E3 /* TestHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9A797C2A98B4AF00E153E3 /* TestHeader.swift */; };
 		1FAFDC352CAB451700F198C3 /* TestTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FAFDC342CAB451700F198C3 /* TestTask.swift */; };
@@ -191,6 +192,7 @@
 		1F66CB792A8FBC1000FC7BA7 /* TestBold.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestBold.swift; sourceTree = "<group>"; };
 		1F66CB7B2A8FBC8F00FC7BA7 /* TestCode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCode.swift; sourceTree = "<group>"; };
 		1F8156CA2F59ECA500D25526 /* TestLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestLink.swift; sourceTree = "<group>"; };
+		1F8156CD2F5AD67F00D25526 /* TestQuotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestQuotes.swift; sourceTree = "<group>"; };
 		1F8538482ADFE12E0011FE81 /* TestEscape.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestEscape.swift; sourceTree = "<group>"; };
 		1F9A797C2A98B4AF00E153E3 /* TestHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHeader.swift; sourceTree = "<group>"; };
 		1FAFDC342CAB451700F198C3 /* TestTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestTask.swift; sourceTree = "<group>"; };
@@ -302,6 +304,7 @@
 				1F02B8592A90D60D0023148B /* TestSyntax.swift */,
 				1F549C1A2D3EF78C00E9AA9E /* TestStrikethrough.swift */,
 				1F8156CA2F59ECA500D25526 /* TestLink.swift */,
+				1F8156CD2F5AD67F00D25526 /* TestQuotes.swift */,
 			);
 			path = CDMarkdownKitTests;
 			sourceTree = "<group>";
@@ -729,6 +732,7 @@
 				1F9A797D2A98B4AF00E153E3 /* TestHeader.swift in Sources */,
 				1F66CB7A2A8FBC1000FC7BA7 /* TestBold.swift in Sources */,
 				1F02B85C2A90D6210023148B /* TestHelpers.swift in Sources */,
+				1F8156CE2F5AD67F00D25526 /* TestQuotes.swift in Sources */,
 				1FAFDC352CAB451700F198C3 /* TestTask.swift in Sources */,
 				1F66CB7C2A8FBC8F00FC7BA7 /* TestCode.swift in Sources */,
 				1F549C1B2D3EF78C00E9AA9E /* TestStrikethrough.swift in Sources */,

--- a/CDMarkdownKitTests/TestCode.swift
+++ b/CDMarkdownKitTests/TestCode.swift
@@ -96,6 +96,13 @@ final class TestCode: XCTestCase {
         XCTAssertTrue(TestHelpers.isMonospaced(testString: parsed, at: 6))
     }
 
+    func testCodeInsideSyntaxOnlyStart() throws {
+        let parser = getParser()
+        
+        let parsed = parser.parse("```\n`oc_mounts`")
+        XCTAssertEqual(parsed.string, "`oc_mounts`")
+        XCTAssertTrue(TestHelpers.isMonospaced(testString: parsed, at: 6))
+    }
 
     /*
      // Expected to fail currently, because the CodeEscaping does not differentiate between code and syntax and always allows new lines

--- a/CDMarkdownKitTests/TestCode.swift
+++ b/CDMarkdownKitTests/TestCode.swift
@@ -88,6 +88,15 @@ final class TestCode: XCTestCase {
         XCTAssertTrue(TestHelpers.isMonospaced(testString: parsed, at: 4))
     }
 
+    func testCodeInsideLink() throws {
+        let parser = getParser()
+
+        let parsed = parser.parse("Test [`Linkname`](link)")
+        XCTAssertEqual(parsed.string, "Test Linkname")
+        XCTAssertTrue(TestHelpers.isMonospaced(testString: parsed, at: 6))
+    }
+
+
     /*
      // Expected to fail currently, because the CodeEscaping does not differentiate between code and syntax and always allows new lines
      func testCodeMultiline() throws {

--- a/CDMarkdownKitTests/TestHelpers.swift
+++ b/CDMarkdownKitTests/TestHelpers.swift
@@ -87,4 +87,18 @@ class TestHelpers {
         return attributes.contains { $0.key == .link && ($0.value as! NSURL).absoluteString == link }
     }
 
+    static func getHeadIndent(testString: NSAttributedString, at location: Int) -> CGFloat {
+        let attributes = testString.attributes(at: location, effectiveRange: nil)
+        let firstParagraphStyle = attributes.first(where: { $0.key == .paragraphStyle })?.value as? NSParagraphStyle
+
+        return firstParagraphStyle?.headIndent ?? 0
+    }
+
+    static func getQuoteLevel(testString: NSAttributedString, at location: Int) -> Int {
+        let attributes = testString.attributes(at: location, effectiveRange: nil)
+        let quoteLevel = attributes.first(where: { $0.key == .quoteLevel })?.value as? NSNumber
+
+        return quoteLevel?.intValue ?? 0
+    }
+
 }

--- a/CDMarkdownKitTests/TestHelpers.swift
+++ b/CDMarkdownKitTests/TestHelpers.swift
@@ -81,5 +81,10 @@ class TestHelpers {
         return attributes.contains { $0.key == .backgroundColor && ($0.value as! UIColor).isEqualTo(otherColor: color) }
     }
 
-    
+    static func hasLink(testString: NSAttributedString, at location: Int, link: String) -> Bool {
+        let attributes = testString.attributes(at: location, effectiveRange: nil)
+
+        return attributes.contains { $0.key == .link && ($0.value as! NSURL).absoluteString == link }
+    }
+
 }

--- a/CDMarkdownKitTests/TestLink.swift
+++ b/CDMarkdownKitTests/TestLink.swift
@@ -1,0 +1,62 @@
+//
+// Copyright (c) 2026 Marcel Müller <marcel-mueller@gmx.de>
+//
+// Author Marcel Müller <marcel-mueller@gmx.de>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import XCTest
+import CDMarkdownKit
+
+final class TestLink: XCTestCase {
+
+    func testLinkWithNormalText() throws {
+        let parser = CDMarkdownParser()
+
+        var parsed = parser.parse("Test [ABC](https://test.invalid)")
+        XCTAssertEqual(parsed.string, "Test ABC")
+        XCTAssertTrue(TestHelpers.hasLink(testString: parsed, at: 6, link: "https://test.invalid"))
+        XCTAssertFalse(TestHelpers.hasLink(testString: parsed, at: 1, link: "https://test.invalid"))
+
+        parsed = parser.parse("[ABC](https://test.invalid) Test")
+        XCTAssertEqual(parsed.string, "ABC Test")
+        XCTAssertTrue(TestHelpers.hasLink(testString: parsed, at: 2, link: "https://test.invalid"))
+        XCTAssertFalse(TestHelpers.hasLink(testString: parsed, at: 6, link: "https://test.invalid"))
+        XCTAssertTrue(TestHelpers.hasLink(testString: parsed, at: 2, link: "https://test.invalid"))
+
+        parsed = parser.parse("Foo [ABC](https://test.invalid) Test")
+        XCTAssertEqual(parsed.string, "Foo ABC Test")
+        XCTAssertFalse(TestHelpers.hasLink(testString: parsed, at: 2, link: "https://test.invalid"))
+        XCTAssertFalse(TestHelpers.hasLink(testString: parsed, at: 3, link: "https://test.invalid"))
+        XCTAssertTrue(TestHelpers.hasLink(testString: parsed, at: 4, link: "https://test.invalid"))
+        XCTAssertTrue(TestHelpers.hasLink(testString: parsed, at: 5, link: "https://test.invalid"))
+        XCTAssertTrue(TestHelpers.hasLink(testString: parsed, at: 6, link: "https://test.invalid"))
+        XCTAssertFalse(TestHelpers.hasLink(testString: parsed, at: 7, link: "https://test.invalid"))
+        XCTAssertFalse(TestHelpers.hasLink(testString: parsed, at: 10, link: "https://test.invalid"))
+    }
+
+    func testLinkOnly() throws {
+        let parser = CDMarkdownParser()
+
+        let parsed = parser.parse("[ABC](https://test.invalid)")
+        XCTAssertEqual(parsed.string, "ABC")
+        XCTAssertTrue(TestHelpers.hasLink(testString: parsed, at: 0, link: "https://test.invalid"))
+        XCTAssertTrue(TestHelpers.hasLink(testString: parsed, at: 1, link: "https://test.invalid"))
+        XCTAssertTrue(TestHelpers.hasLink(testString: parsed, at: 2, link: "https://test.invalid"))
+    }
+
+}

--- a/CDMarkdownKitTests/TestQuotes.swift
+++ b/CDMarkdownKitTests/TestQuotes.swift
@@ -1,0 +1,102 @@
+//
+// Copyright (c) 2026 Marcel Müller <marcel-mueller@gmx.de>
+//
+// Author Marcel Müller <marcel-mueller@gmx.de>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import XCTest
+import CDMarkdownKit
+
+final class TestQuotes: XCTestCase {
+
+    func testQuoteOnly() throws {
+        let parser = CDMarkdownParser()
+
+        let parsed = parser.parse("> Hello")
+        XCTAssertEqual(parsed.string, "Hello")
+        XCTAssertGreaterThan(TestHelpers.getHeadIndent(testString: parsed, at: 0), 0)
+    }
+
+    func testQuoteSingleNewline() throws {
+        let parser = CDMarkdownParser()
+
+        var parsed = parser.parse("> Hello\nHello again")
+        XCTAssertEqual(parsed.string, "Hello\nHello again")
+        XCTAssertGreaterThan(TestHelpers.getHeadIndent(testString: parsed, at: 0), 0)
+        XCTAssertGreaterThan(TestHelpers.getHeadIndent(testString: parsed, at: 8), 0)
+
+        parsed = parser.parse("> Hello\n>Hello again")
+        XCTAssertEqual(parsed.string, "Hello\nHello again")
+        XCTAssertGreaterThan(TestHelpers.getHeadIndent(testString: parsed, at: 0), 0)
+        XCTAssertGreaterThan(TestHelpers.getHeadIndent(testString: parsed, at: 10), 0)
+    }
+
+    func testQuoteMultiple() throws {
+        let parser = CDMarkdownParser()
+        parser.squashNewlines = false
+        parser.trimLeadingWhitespaces = false
+
+        let parsed = parser.parse("Normal\n> Hello\nHello again\n\nNormal again")
+        XCTAssertEqual(parsed.string, "Normal\nHello\nHello again\n\nNormal again")
+        XCTAssertEqual(TestHelpers.getHeadIndent(testString: parsed, at: 0), 0)
+        XCTAssertGreaterThan(TestHelpers.getHeadIndent(testString: parsed, at: 8), 0)
+        XCTAssertEqual(TestHelpers.getQuoteLevel(testString: parsed, at: 8), 0)
+        XCTAssertGreaterThan(TestHelpers.getHeadIndent(testString: parsed, at: 16), 0)
+        XCTAssertEqual(TestHelpers.getQuoteLevel(testString: parsed, at: 16), 0)
+        XCTAssertEqual(TestHelpers.getHeadIndent(testString: parsed, at: 24), 0)
+    }
+
+    func testQuoteSingleNested() throws {
+        let parser = CDMarkdownParser()
+
+        let parsed = parser.parse(">> Hello")
+        XCTAssertEqual(parsed.string, "Hello")
+        XCTAssertGreaterThan(TestHelpers.getHeadIndent(testString: parsed, at: 0), 15)
+        XCTAssertEqual(TestHelpers.getQuoteLevel(testString: parsed, at: 0), 1)
+    }
+
+    func testQuoteNested() throws {
+        let parser = CDMarkdownParser()
+        parser.squashNewlines = false
+        parser.trimLeadingWhitespaces = false
+
+        var parsed = parser.parse("> Hello\n>> Hello")
+        XCTAssertEqual(parsed.string, "Hello\nHello")
+        XCTAssertGreaterThan(TestHelpers.getHeadIndent(testString: parsed, at: 0), 0)
+        XCTAssertEqual(TestHelpers.getQuoteLevel(testString: parsed, at: 0), 0)
+        XCTAssertGreaterThan(TestHelpers.getHeadIndent(testString: parsed, at: 6), 15)
+        XCTAssertEqual(TestHelpers.getQuoteLevel(testString: parsed, at: 6), 1)
+
+        parsed = parser.parse("> Hello\n\n>> Hello")
+        XCTAssertEqual(parsed.string, "Hello\n\nHello")
+        XCTAssertGreaterThan(TestHelpers.getHeadIndent(testString: parsed, at: 0), 0)
+        XCTAssertEqual(TestHelpers.getQuoteLevel(testString: parsed, at: 0), 0)
+        XCTAssertGreaterThan(TestHelpers.getHeadIndent(testString: parsed, at: 7), 15)
+        XCTAssertEqual(TestHelpers.getQuoteLevel(testString: parsed, at: 7), 1)
+
+        parsed = parser.parse("> Hello\n\n>> Hello\n>> Hello")
+        XCTAssertEqual(parsed.string, "Hello\n\nHello\nHello")
+        XCTAssertGreaterThan(TestHelpers.getHeadIndent(testString: parsed, at: 0), 0)
+        XCTAssertEqual(TestHelpers.getQuoteLevel(testString: parsed, at: 0), 0)
+        XCTAssertGreaterThan(TestHelpers.getHeadIndent(testString: parsed, at: 7), 15)
+        XCTAssertEqual(TestHelpers.getQuoteLevel(testString: parsed, at: 7), 1)
+        XCTAssertGreaterThan(TestHelpers.getHeadIndent(testString: parsed, at: 14), 15)
+        XCTAssertEqual(TestHelpers.getQuoteLevel(testString: parsed, at: 14), 1)
+    }
+
+}

--- a/CDMarkdownKitTests/TestSyntax.swift
+++ b/CDMarkdownKitTests/TestSyntax.swift
@@ -116,8 +116,25 @@ final class TestSyntax: XCTestCase {
     func testSyntaxOnlyStart() throws {
         let parser = getParser()
 
-        let parsed = parser.parse("```\nsyntax\n")
-        XCTAssertEqual(parsed.string, "```\nsyntax\n")
-        XCTAssertFalse(TestHelpers.isMonospaced(testString: parsed, at: 4))
+        let parsed = parser.parse("```\nsyntax")
+        XCTAssertEqual(parsed.string, "syntax")
+        XCTAssertTrue(TestHelpers.isMonospaced(testString: parsed, at: 4))
     }
+
+    func testSyntaxOnlyStartNewline() throws {
+        let parser = getParser()
+
+        let parsed = parser.parse("```\nsyntax\n")
+        XCTAssertEqual(parsed.string, "syntax\n")
+        XCTAssertTrue(TestHelpers.isMonospaced(testString: parsed, at: 4))
+    }
+
+    func testSyntaxUnevenClosure() throws {
+        let parser = getParser()
+
+        let parsed = parser.parse("```\nsyntax\n``")
+        XCTAssertEqual(parsed.string, "syntax\n``")
+        XCTAssertTrue(TestHelpers.isMonospaced(testString: parsed, at: 4))
+    }
+
 }

--- a/CDMarkdownKitTests/TestTask.swift
+++ b/CDMarkdownKitTests/TestTask.swift
@@ -1,0 +1,61 @@
+//
+// Copyright (c) 2024 Marcel Müller <marcel-mueller@gmx.de>
+//
+// Author Marcel Müller <marcel-mueller@gmx.de>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import XCTest
+import CDMarkdownKit
+
+final class TestTask: XCTestCase {
+
+    func getParser() -> CDMarkdownParser {
+        let parser = CDMarkdownParser()
+
+        return parser
+    }
+
+    func testTaskSingle() throws {
+        let parser = getParser()
+        let parsed = parser.parse("- [] ABC")
+
+        XCTAssertTrue(parsed.string.contains("ABC"))
+        XCTAssertFalse(parsed.string.contains("[]"))
+        XCTAssertFalse(parsed.string.contains("-"))
+
+        parsed.containsAttachments(in: NSRange(location: 0, length: parsed.length))
+    }
+
+    func testTaskMultiple() throws {
+        let parser = getParser()
+        let parsed = parser.parse("- [] ABC\n- [x] DEF")
+
+        var attachmentCount = 0
+
+        parsed.enumerateAttribute(.attachment, in: NSRange(location: 0, length: parsed.length)) { value, _, _ in
+            if value is NSTextAttachment {
+                attachmentCount += 1
+            }
+        }
+
+        XCTAssertEqual(attachmentCount, 2)
+    }
+
+
+
+}

--- a/Source/CDMarkdownCode.swift
+++ b/Source/CDMarkdownCode.swift
@@ -33,7 +33,7 @@
 
 open class CDMarkdownCode: CDMarkdownCommonElement {
 
-    fileprivate static let regex = ["((?<!`))(`{1,2})(\\s*?[^`]*?\\s*?)(\\2)(?!`)"]
+    fileprivate static let regex = ["((?<!`))(`{1,2})(\\s*?[^`]*?\\s*?)(\\2|$)(?!`)"]
 
     open var font: CDFont?
     open var color: CDColor?

--- a/Source/CDMarkdownCodeEscaping.swift
+++ b/Source/CDMarkdownCodeEscaping.swift
@@ -33,7 +33,7 @@
 
 open class CDMarkdownCodeEscaping: CDMarkdownElement {
 
-    fileprivate static let regex = ["(?<!\\\\)(?:\\\\\\\\)*+(`+(?!`))([\\s\\S]*?)(\\1)"]
+    fileprivate static let regex = ["(?<!\\\\)(?:\\\\\\\\)*+(`+(?!`))([\\s\\S]*?)(\\1|$)"]
     open var enabled: Bool = true
 
     lazy open var regularExpressions: [NSRegularExpression] = {
@@ -45,6 +45,10 @@ open class CDMarkdownCodeEscaping: CDMarkdownElement {
                     attributedString: NSMutableAttributedString) {
 
         let range = match.nsRange(atIndex: 2)
+
+        if range.length == 0 {
+            return
+        }
 
         // escaping all characters
         var matchString = attributedString.attributedSubstring(from: range).string

--- a/Source/CDMarkdownCommonElement.swift
+++ b/Source/CDMarkdownCommonElement.swift
@@ -46,13 +46,6 @@ public extension CDMarkdownCommonElement {
     }
 
     func match(_ match: NSTextCheckingResult, attributedString: NSMutableAttributedString) {
-        let attributes = attributedString.attributes(at: match.nsRange(atIndex: 3).lowerBound, effectiveRange: nil)
-
-        // Don't format parts of the string which already contain a link
-        if attributes.contains(where: { $0.key == .link}) {
-            return
-        }
-
         // deleting trailing markdown
         attributedString.deleteCharacters(in: match.nsRange(atIndex: 4))
         // formatting string (may alter the length)

--- a/Source/CDMarkdownLink.swift
+++ b/Source/CDMarkdownLink.swift
@@ -33,7 +33,7 @@
 
 open class CDMarkdownLink: CDMarkdownLinkElement {
 
-    fileprivate static let regex = ["[^!{1}]\\[([^\\[]*?)\\]\\(([^\\)]*)\\)"]
+    fileprivate static let regex = ["(?:^|(?<!!))\\[([^\\[]*?)\\]\\(([^\\)]*)\\)"]
 
     open var font: CDFont?
     open var color: CDColor?
@@ -70,14 +70,12 @@ open class CDMarkdownLink: CDMarkdownLinkElement {
     open func formatText(_ attributedString: NSMutableAttributedString,
                          range: NSRange,
                          link: String) {
-        guard let encodedLink = link.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlHostAllowed)
-            else {
-                return
-        }
-        guard let url = URL(string: link) ?? URL(string: encodedLink) else { return }
 
-        attributedString.addLink(url,
-                                 toRange: range)
+        guard let encodedLink = link.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlHostAllowed),
+              let url = URL(string: link) ?? URL(string: encodedLink)
+        else { return }
+
+        attributedString.addLink(url, toRange: range)
     }
 
     open func match(_ match: NSTextCheckingResult,
@@ -100,10 +98,10 @@ open class CDMarkdownLink: CDMarkdownLinkElement {
 
         // deleting leading markdown
         // needs to be called before formattingBlock to provide a stable range
-        attributedString.deleteCharacters(in: NSRange(location: match.range.location + 1,
+        attributedString.deleteCharacters(in: NSRange(location: match.range.location,
                                                       length: 1))
-        let formatRange = NSRange(location: match.range.location + 1,
-                                  length: linkStartInResult - match.range.location - 3)
+        let formatRange = NSRange(location: match.range.location,
+                                  length: linkStartInResult - match.range.location - 2)
 
         formatText(attributedString,
                    range: formatRange,

--- a/Source/CDMarkdownParser.swift
+++ b/Source/CDMarkdownParser.swift
@@ -43,6 +43,7 @@ open class CDMarkdownParser {
     // MARK: - Basic Elements
     public let header: CDMarkdownHeader
     public let list: CDMarkdownList
+    public let task: CDMarkdownTask
     public let quote: CDMarkdownQuote
     public let link: CDMarkdownLink
     public let automaticLink: CDMarkdownAutomaticLink
@@ -108,6 +109,10 @@ open class CDMarkdownParser {
                               color: fontColor,
                               backgroundColor: backgroundColor,
                               paragraphStyle: paragraphStyle)
+        task = CDMarkdownTask(font: font,
+                              color: fontColor,
+                              backgroundColor: backgroundColor,
+                              paragraphStyle: paragraphStyle)
         quote = CDMarkdownQuote(font: font,
                                 color: fontColor,
                                 backgroundColor: backgroundColor,
@@ -154,9 +159,9 @@ open class CDMarkdownParser {
         self.squashNewlines = squashNewlines
         self.escapingElements = [codeEscaping, escaping]
 #if os(iOS) || os(macOS) || os(tvOS)
-        self.defaultElements = [header, list, quote, link, automaticLink, image, bold, italic, strikethrough]
+        self.defaultElements = [header, task, list, quote, link, automaticLink, image, bold, italic, strikethrough]
 #else
-        self.defaultElements = [header, list, quote, link, automaticLink, bold, italic, strikethrough]
+        self.defaultElements = [header, task, list, quote, link, automaticLink, bold, italic, strikethrough]
 #endif
         self.unescapingElements = [code, syntax, unescaping]
         self.customElements = customElements

--- a/Source/CDMarkdownQuote.swift
+++ b/Source/CDMarkdownQuote.swift
@@ -33,12 +33,11 @@
 
 open class CDMarkdownQuote: CDMarkdownLevelElement {
 
-    fileprivate static let regex = "^(\\>{1,%@})\\s*(.+)$"
+    fileprivate static let regex = "(?:(?<=\\n)|^)(\\>{1,%@})\\s*(.+?)(?:(?=\\n\\n)|$|(?=\\>))"
 
     open var font: CDFont?
     open var maxLevel: Int
     open var indicator: String
-    open var separator: String
     open var color: CDColor?
     open var backgroundColor: CDColor?
     open var paragraphStyle: NSParagraphStyle?
@@ -51,13 +50,12 @@ open class CDMarkdownQuote: CDMarkdownLevelElement {
         let formattedRegex = String(format: CDMarkdownQuote.regex, level)
 
         // swiftlint:disable:next force_try
-        return [try! NSRegularExpression(pattern: formattedRegex, options: .anchorsMatchLines)]
+        return [try! NSRegularExpression(pattern: formattedRegex, options: .dotMatchesLineSeparators)]
     }()
 
     public init(font: CDFont? = nil,
                 maxLevel: Int = 0,
                 indicator: String = ">",
-                separator: String = "  ",
                 color: CDColor? = nil,
                 backgroundColor: CDColor? = nil,
                 paragraphStyle: NSParagraphStyle? = nil,
@@ -66,7 +64,6 @@ open class CDMarkdownQuote: CDMarkdownLevelElement {
         self.font = font
         self.maxLevel = maxLevel
         self.indicator = indicator
-        self.separator = separator
         self.color = color
         self.backgroundColor = backgroundColor
         self.paragraphStyle = paragraphStyle
@@ -98,6 +95,6 @@ open class CDMarkdownQuote: CDMarkdownLevelElement {
     }
 }
 
-extension NSAttributedString.Key {
+public extension NSAttributedString.Key {
     static let quoteLevel: NSAttributedString.Key = .init("quoteLevel")
 }

--- a/Source/CDMarkdownSyntax.swift
+++ b/Source/CDMarkdownSyntax.swift
@@ -33,7 +33,7 @@
 
 open class CDMarkdownSyntax: CDMarkdownCommonElement {
 
-    fileprivate static let regex = ["()(`{3})(\\s*[^`]*?\\s*)(\\2)(?!`)"]
+    fileprivate static let regex = ["()(`{3})(\\s*[^`]*?\\s*?)(\\2|$)(?!`)"]
 
     open var font: CDFont?
     open var color: CDColor?

--- a/Source/CDMarkdownTask.swift
+++ b/Source/CDMarkdownTask.swift
@@ -1,10 +1,10 @@
 //
-//  CDMarkdownList.swift
+//  CDMarkdownTask.swift
 //  CDMarkdownKit
 //
-//  Created by Christopher de Haan on 11/7/16.
+//  Created by Marcel Müller on 30/09/24.
 //
-//  Copyright © 2016-2022 Christopher de Haan <contact@christopherdehaan.me>
+//  Copyright (c) 2024 Marcel Müller <marcel-mueller@gmx.de>
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -31,13 +31,28 @@
     import Cocoa
 #endif
 
-open class CDMarkdownList: CDMarkdownLevelElement {
+open class CDMarkdownTask: CDMarkdownLevelElement {
 
-    fileprivate static let regex = "^\\s*([\\*\\+\\-]{1,%@})[ \t]+(.+)$"
+    fileprivate static let regex = "^\\s*([\\*\\+\\-]{1,%@})[ \t]+\\[[ xX]?\\](.+)$"
+    
+    fileprivate static var checkedTextAttachment: NSTextAttachment = {
+        if let checkedImage = UIImage(systemName: "checkmark.square.fill")?.withTintColor(.secondaryLabel).withRenderingMode(.alwaysOriginal) {
+            return NSTextAttachment(image: checkedImage)
+        }
+
+        return NSTextAttachment()
+    }()
+
+    fileprivate static var uncheckedTextAttachment: NSTextAttachment = {
+        if let checkedImage = UIImage(systemName: "square")?.withTintColor(.secondaryLabel).withRenderingMode(.alwaysOriginal) {
+            return NSTextAttachment(image: checkedImage)
+        }
+
+        return NSTextAttachment()
+    }()
 
     open var font: CDFont?
     open var maxLevel: Int
-    open var indicator: String
     open var separator: String
     open var color: CDColor?
     open var backgroundColor: CDColor?
@@ -49,7 +64,7 @@ open class CDMarkdownList: CDMarkdownLevelElement {
 
     lazy open var regularExpressions: [NSRegularExpression] = {
         let level: String = maxLevel > 0 ? "\(maxLevel)" : ""
-        let formattedRegex = String(format: CDMarkdownList.regex, level)
+        let formattedRegex = String(format: CDMarkdownTask.regex, level)
 
         // swiftlint:disable:next force_try
         return [try! NSRegularExpression(pattern: formattedRegex, options: .anchorsMatchLines)]
@@ -57,7 +72,6 @@ open class CDMarkdownList: CDMarkdownLevelElement {
 
     public init(font: CDFont? = nil,
                 maxLevel: Int = 0,
-                indicator: String = "•",
                 separator: String = "  ",
                 color: CDColor? = nil,
                 backgroundColor: CDColor? = nil,
@@ -66,7 +80,6 @@ open class CDMarkdownList: CDMarkdownLevelElement {
                 underlineStyle: NSUnderlineStyle? = nil) {
         self.font = font
         self.maxLevel = maxLevel
-        self.indicator = indicator
         self.separator = separator
         self.color = color
         self.backgroundColor = backgroundColor
@@ -87,12 +100,42 @@ open class CDMarkdownList: CDMarkdownLevelElement {
     open func formatText(_ attributedString: NSMutableAttributedString,
                          range: NSRange,
                          level: Int) {
-        var string = (0..<level).reduce("") { (string, _) -> String in
+        var string = (0..<level-1).reduce("") { (string, _) -> String in
             return "\(string)\(separator)"
         }
-        string = "\(string)\(indicator) "
+        string = "\(string) "
+
+        let rawString = attributedString.string
+
+        guard let convertedRange = Range(range, in: rawString) else { return }
+
+        let subString = rawString[convertedRange]
+        var textAttachment: NSTextAttachment
+
+        // subString is only the indicator part, so "- []" or "- [x]"
+        // so it's safe to check for "[x]" without a range check
+        if subString.contains("[x]") {
+            textAttachment = CDMarkdownTask.checkedTextAttachment
+        } else {
+            textAttachment = CDMarkdownTask.uncheckedTextAttachment
+        }
+
+        let attributedResult = NSMutableAttributedString(string: string)
+        attributedResult.append(NSAttributedString(attachment: textAttachment))
+
+        if let font = indicatorFont {
+            let range = NSRange(location: 0, length: attributedResult.length)
+            attributedResult.addFont(font, toRange: range)
+        }
+
+        // We need to keep the paragraphe style, that was previously applied in addFullAttributed
+        if let paragraphStyle = attributedString.attribute(.paragraphStyle, at: range.location, effectiveRange: nil) as? NSParagraphStyle {
+            let range = NSRange(location: 0, length: attributedResult.length)
+            attributedResult.addParagraphStyle(paragraphStyle, toRange: range)
+        }
+
         attributedString.replaceCharacters(in: range,
-                                           with: string)
+                                           with: attributedResult)
     }
 
     open func addFullAttributes(_ attributedString: NSMutableAttributedString,
@@ -106,7 +149,17 @@ open class CDMarkdownList: CDMarkdownLevelElement {
             attributesForSizing.addFont(sizingFont)
         }
 
-        let indicatorSize = "\(indicator) ".sizeWithAttributes(attributesForSizing)
+        var indicatorSize = CGSize()
+
+        if #available(iOS 18.0, *) {
+            let indicator = NSAttributedString(attachment: CDMarkdownTask.checkedTextAttachment, attributes: attributesForSizing)
+            indicatorSize = indicator.size()
+        } else {
+            let indicator = NSMutableAttributedString(attachment: CDMarkdownTask.checkedTextAttachment)
+            indicator.addAttributes(attributesForSizing, range: .init(location: 0, length: indicator.length))
+            indicatorSize = indicator.size()
+        }
+
         let separatorSize = separator.sizeWithAttributes(attributesForSizing)
 
         let floatLevel = CGFloat(level)


### PR DESCRIPTION
Fixes:
- Syntax with uneven backticks
- Syntax with no end-backticks
- Code inside syntax
- Code inside links
- Task support
- Multline quotes