### PR TITLE
Quote fixes

### DIFF
--- a/CDMarkdownKitTests/TestQuotes.swift
+++ b/CDMarkdownKitTests/TestQuotes.swift
@@ -99,4 +99,22 @@ final class TestQuotes: XCTestCase {
         XCTAssertEqual(TestHelpers.getQuoteLevel(testString: parsed, at: 14), 1)
     }
 
+    func testQuoteWithIndicator() throws {
+        let parser = CDMarkdownParser()
+
+        let parsed = parser.parse("> This <-> That")
+        XCTAssertEqual(parsed.string, "This <-> That")
+        XCTAssertGreaterThan(TestHelpers.getHeadIndent(testString: parsed, at: 0), 0)
+        XCTAssertEqual(TestHelpers.getQuoteLevel(testString: parsed, at: 0), 0)
+
+        let paragraphStyleStart = parsed.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+        let paragraphStyleEnd = parsed.attribute(.paragraphStyle, at: 12, effectiveRange: nil) as? NSParagraphStyle
+
+        XCTAssertNotNil(paragraphStyleStart)
+
+        // Ensure the paragraphStyle is for the whole line and not split at ">"
+        XCTAssertEqual(paragraphStyleStart, paragraphStyleEnd)
+    }
+
+
 }

--- a/Source/CDMarkdownLayoutManager.swift
+++ b/Source/CDMarkdownLayoutManager.swift
@@ -59,15 +59,25 @@ open class CDMarkdownLayoutManager: NSLayoutManager {
             let textRectFirstLine = self.boundingRect(forGlyphRange: glyphRangeFirstLine, in: textContainer)
 
             // Create a rect that would later become our quote indicator (the bar on the left side of the quote)
-            let newRect = CGRect(x: textRectFirstLine.origin.x - 9, y: textRect.origin.y + 2, width: 4, height: textRect.size.height - 4)
+            let yPadding = 2.0
+            let newRect = CGRect(x: textRectFirstLine.origin.x - 9, y: textRect.origin.y + yPadding, width: 4, height: textRect.size.height - (2 * yPadding))
+
+            var addCurrentRect = true
 
             for rectIdx in previousRects.indices.reversed() {
                 var (level, rect) = previousRects[rectIdx]
 
-                if level < currentLevel {
+                let rectBottom = rect.maxY + (2 * yPadding)
+
+                if level <= currentLevel, newRect.minY <= rectBottom {
                     // If there are lower levels than the current one, we want to adjust the height to include the current level
                     rect = CGRect(x: rect.origin.x, y: rect.origin.y, width: rect.size.width, height: rect.size.height + textRect.size.height)
                     previousRects[rectIdx] = (level, rect)
+
+                    // If it's the same level, we don't want to draw the same rect twice, but we need to continue to adjust other previousRects as well
+                    if level == currentLevel {
+                        addCurrentRect = false
+                    }
                 } else {
                     // If there are higher levels than the current one, we want to draw these rects now
                     UIBezierPath(roundedRect: rect, cornerRadius: 2).fill()
@@ -75,7 +85,9 @@ open class CDMarkdownLayoutManager: NSLayoutManager {
                 }
             }
 
-            previousRects.append((currentLevel, newRect))
+            if addCurrentRect {
+                previousRects.append((currentLevel, newRect))
+            }
         })
 
         // Any remaining rects need to be drawn now

--- a/Source/CDMarkdownQuote.swift
+++ b/Source/CDMarkdownQuote.swift
@@ -33,7 +33,7 @@
 
 open class CDMarkdownQuote: CDMarkdownLevelElement {
 
-    fileprivate static let regex = "(?:(?<=\\n)|^)(\\>{1,%@})\\s*(.+?)(?:(?=\\n\\n)|$|(?=\\>))"
+    fileprivate static let regex = "(?:(?<=\\n)|^)(\\>{1,%@})\\s*(.+?)(?:(?=\\n\\n)|$|(?=\\n\\>))"
 
     open var font: CDFont?
     open var maxLevel: Int


### PR DESCRIPTION
When a ">" appeared inside of a quote, that would split the paragraphStyle. While not an issue per se, it is an issue when drawing the quote indicator.

Also the drawing in general was adjusted and should now work much better in nested situations, e.g.

```
> test
>> test
> asd

> 2
```

Before (notice that the first quote indicator only spans 2 lines):
<img width="118" height="150" alt="image" src="https://github.com/user-attachments/assets/2810bec3-33c9-47a7-a66d-0ddb78b37900" />

After:
<img width="129" height="154" alt="Bildschirmfoto 2026-03-06 um 17 16 29" src="https://github.com/user-attachments/assets/258281a6-f629-4dc5-8abd-a80f9a4f1d2f" />
